### PR TITLE
Prevent extra renders

### DIFF
--- a/src/common/exchangeInterfaces.ts
+++ b/src/common/exchangeInterfaces.ts
@@ -13,7 +13,7 @@ export type IDFColMap = {
 
 // data fetched from kernel for frontend
 export type IColumnProfileMap = {
-    [dfname: string]: Promise<IColumnProfileWrapper>;
+    [dfname: string]: IColumnProfileWrapper;
 };
 
 export type IColumnProfileWrapper = {

--- a/src/components/DFProfile.svelte
+++ b/src/components/DFProfile.svelte
@@ -24,37 +24,27 @@
             </div>
             <p class="inline-block font-bold">{dfName}</p>
 
-            {#await $columnProfiles[dfName]}
-                <div class="inline-block align-middle pl-2">
-                    <!-- <Pulse size="1" color="#FF3E00" unit="rem" duration="1s" /> -->
-                    <Circle size="1" color="#FF3E00" unit="rem" duration="1s" />
-                </div>
-            {:then cp}
-                <p class="inline-block">
-                    {cp.shape?.[0]} x {cp.shape?.[1]}
-                </p>
-            {/await}
+            <p class="inline-block">
+                {$columnProfiles[dfName].shape?.[0]} x 
+                {$columnProfiles[dfName].shape?.[1]}
+            </p>
         </div>
 
         <div slot="body" class="dfprofile-body">
-            {#await $columnProfiles[dfName]}
-                <div />
-            {:then cp}
-                <div bind:clientWidth={profileWidth} class="col-profiles">
-                    {#each cp.profile as column}
-                        <ColumnProfile
-                            example={column.example}
-                            name={column.name}
-                            type={column.type}
-                            summary={column.summary}
-                            nullCount={column.nullCount}
-                            containerWidth={profileWidth}
-                            view={previewView}
-                            totalRows={cp.shape?.[0]}
-                        />
-                    {/each}
-                </div>
-            {/await}
+            <div bind:clientWidth={profileWidth} class="col-profiles">
+                {#each $columnProfiles[dfName].profile as column}
+                    <ColumnProfile
+                        example={column.example}
+                        name={column.name}
+                        type={column.type}
+                        summary={column.summary}
+                        nullCount={column.nullCount}
+                        containerWidth={profileWidth}
+                        view={previewView}
+                        totalRows={$columnProfiles[dfName].shape?.[0]}
+                    />
+                {/each}
+            </div>
         </div>
     </CollapsibleCard>
 </div>

--- a/src/components/Profiler.svelte
+++ b/src/components/Profiler.svelte
@@ -1,8 +1,14 @@
 <script lang="ts">
     import _ from 'lodash';
     import DFProfile from './DFProfile.svelte';
-    import { columnProfiles, dataFramesAndCols, profileModel } from '../stores';
+    import {
+        columnProfiles,
+        dataFramesAndCols,
+        profileModel,
+        isLoadingNewData
+    } from '../stores';
     import Parquet from './icons/Parquet.svelte';
+    import { Circle } from 'svelte-loading-spinners';
 
     // Locals
     let name: string;
@@ -35,6 +41,16 @@
                     <Parquet size="16px" />
                 </div>
                 <h2 class="inline-block align-middle">DataFrames</h2>
+                {#if $isLoadingNewData}
+                    <div class="inline-block align-middle pl-2">
+                        <Circle
+                            size="1"
+                            color="#FF3E00"
+                            unit="rem"
+                            duration="1s"
+                        />
+                    </div>
+                {/if}
             </div>
 
             <div>


### PR DESCRIPTION
## Functionality
<!-- What does this PR do? -->
- Only re-renders when necessary instead of on every new cell execution run
- Does so by fetching all data and then updating the store rather than passing as a promise
- Add a new spinner at top level in order to show that the UI is updating since there are no more spinners at dataframe level

## Issues addressed
<!-- What issues does this fix or address? Reference them as Fixes #4 and they will be closed automatically when the PR is merged -->

Fixes #8 
