### PR TITLE
bump max bins from 10 to 20 for Q charts

### DIFF
--- a/src/dataAPI/jupyter/PythonExecutor.ts
+++ b/src/dataAPI/jupyter/PythonExecutor.ts
@@ -346,7 +346,7 @@ export class PythonPandasExecutor {
     public async getQuantBinnedData(
         dfName: string,
         colName: string,
-        maxbins = 10
+        maxbins = 20
     ): Promise<IHistogram> {
         /*
          *   Returns data for VL spec to plot quant data. In form of array of shape


### PR DESCRIPTION
## Functionality

- Increase max bins for Q charts from 10 to 20

## Issues addressed

Fixes #26 