### PR TITLE
include zoom number

### DIFF
--- a/src/components/viz/timestamp/TimestampDetail.svelte
+++ b/src/components/viz/timestamp/TimestampDetail.svelte
@@ -13,6 +13,7 @@
      * The graph will contain an unsmoothed series (showing noise * abnormalities) by default, and
      * a smoothed series (showing the trend) if the time series merits it.
      */
+    import _ from 'lodash';
     import { onMount, setContext } from 'svelte';
     import { guidGenerator } from '../../utils/guid';
     import { spring } from 'svelte/motion';
@@ -299,7 +300,13 @@
 </script>
 
 <div style:width="100%">
-    <TimestampProfileSummary {interval} />
+    <TimestampProfileSummary
+        {interval}
+        numZoomedRows={zoomedRows}
+        numTotalRows={~~data.reduce((a, b) => a + b[yAccessor], 0)}
+        zoomed={!_.isUndefined($zoomCoords.start.x) ||
+            !_.isUndefined(zoomedXStart)}
+    />
     <svg
         width="100%"
         {height}

--- a/src/components/viz/timestamp/TimestampProfileSummary.svelte
+++ b/src/components/viz/timestamp/TimestampProfileSummary.svelte
@@ -4,11 +4,17 @@
      * This component provides summary information about the
      * timestamp profile at the top of the detail plot.
      */
-    import { intervalToTimestring } from '../../utils/formatters';
+    import {
+        intervalToTimestring,
+        formatBigNumberPercentage
+    } from '../../utils/formatters';
 
     import type { Interval } from '../../../common/exchangeInterfaces';
 
     export let interval: Interval;
+    export let numTotalRows: number;
+    export let numZoomedRows: number;
+    export let zoomed = false;
 </script>
 
 <div
@@ -18,10 +24,20 @@
         grid-template-columns: auto;
     "
 >
-    <div>
-        {#if interval}
-            Range is {intervalToTimestring(interval)}
-        {/if}
+    <div class="flex">
+        <div class="grow">
+            {#if interval}
+                Range is {intervalToTimestring(interval)}
+            {/if}
+        </div>
+        <div class="text-right">
+            {#if zoomed}
+                Zoomed to {numZoomedRows} rows ({formatBigNumberPercentage(
+                    numZoomedRows / numTotalRows
+                )}).
+            {/if}
+        </div>
     </div>
+
     <div class="text-gray-400">Ctrl + Click + Drag to zoom</div>
 </div>


### PR DESCRIPTION
## Functionality

For timestamps, include the number of rows in the zoom and the % of total 

## Issues addressed

Fixes #47