### PR TITLE
more descriptive labels for timestamp charts and zoom

### DIFF
--- a/src/common/exchangeInterfaces.ts
+++ b/src/common/exchangeInterfaces.ts
@@ -75,7 +75,9 @@ export interface TimeColumnSummary {
 
 export type TimeBin = {
     count: number;
-    ts: Date;
+    ts_start: Date;
+    ts_end: Date;
+    ts_midpoint: Date; // halfway between start and end
 };
 
 export type ValueCount = {

--- a/src/common/exchangeInterfaces.ts
+++ b/src/common/exchangeInterfaces.ts
@@ -77,7 +77,6 @@ export type TimeBin = {
     count: number;
     ts_start: Date;
     ts_end: Date;
-    ts_midpoint: Date; // halfway between start and end
 };
 
 export type ValueCount = {

--- a/src/components/ColumnProfile.svelte
+++ b/src/components/ColumnProfile.svelte
@@ -193,7 +193,7 @@
                         {:else if TIMESTAMPS.has(type) && summary?.timeSummary}
                             <TimestampDetail
                                 data={summary?.timeSummary.rollup.results}
-                                xAccessor="ts"
+                                xAccessor="ts_end"
                                 yAccessor="count"
                                 height={160}
                                 width={wrapperDivWidth}

--- a/src/components/viz/histogram/SmallHistogram.svelte
+++ b/src/components/viz/histogram/SmallHistogram.svelte
@@ -1,14 +1,8 @@
 <script lang="ts">
     import HistogramBase from './HistogramBase.svelte';
+    import type { IHistogram } from '../../../common/exchangeInterfaces';
 
-    interface HistogramBin {
-        bucket: number;
-        low: number;
-        high: number;
-        count: number;
-    }
-
-    export let data: HistogramBin[];
+    export let data: IHistogram;
     export let width = 60;
     export let height = 19;
     export let fillColor = 'hsl(340, 70%, 70%)';

--- a/src/components/viz/timestamp/TimestampDetail.svelte
+++ b/src/components/viz/timestamp/TimestampDetail.svelte
@@ -33,11 +33,6 @@
     import TimestampBound from './TimestampBound.svelte';
     import TimestampProfileSummary from './TimestampProfileSummary.svelte';
 
-    // import Tooltip from '../../../tooltip/Tooltip.svelte';
-    // import TimestampTooltipContent from './TimestampTooltipContent.svelte';
-
-    // import { createShiftClickAction } from '../../../../util/shift-click-action';
-    // import notifications from '../../../notifications';
     import TimestampMouseoverAnnotation from './TimestampMouseoverAnnotation.svelte';
     import TimestampPaths from './TimestampPaths.svelte';
 
@@ -46,8 +41,8 @@
 
     const id = guidGenerator();
 
+    // data is assumed to be sorted
     export let data: TimeBin[];
-    // export let spark: TimeBin[];
 
     export let width = 360;
     export let height = 120;
@@ -189,8 +184,9 @@
     let zoomedXStart: Date;
     let zoomedXEnd: Date;
     // establish basis values
-    let xExtents = extent(data, d => d[xAccessor]);
-    $: xExtents = extent(data, d => d[xAccessor]);
+    let xExtents = [data[0]?.ts_start, data[data.length - 1]?.ts_end];
+    // $: xExtents = extent(data, d => d[xAccessor]);
+    $: xExtents = [data[0]?.ts_start, data[data.length - 1]?.ts_end];
 
     const xMin = createExtremumResolutionStore(xExtents[0], {
         duration: 300,
@@ -427,7 +423,7 @@
             <text
                 font-size={fontSize}
                 x={$plotConfig.plotRight}
-                y={fontSize}
+                y={$plotConfig.fontSize * 2 + $plotConfig.textGap}
                 text-anchor="end"
                 style:font-style="italic"
                 style:user-select="none"

--- a/src/components/viz/timestamp/TimestampMouseoverAnnotation.svelte
+++ b/src/components/viz/timestamp/TimestampMouseoverAnnotation.svelte
@@ -5,8 +5,10 @@
         datePortion,
         formatInteger,
         removeTimezoneOffset,
-        timePortion
+        timePortion,
+        standardTimestampFormat
     } from '../../utils/formatters';
+    import type { TimeBin } from '../../../common/exchangeInterfaces';
     import { getContext } from 'svelte';
 
     import type { Writable } from 'svelte/store';
@@ -23,10 +25,11 @@
         'rill:data-graphic:plot-config'
     );
 
-    export let point;
+    export let point: TimeBin;
     export let xAccessor: string;
     export let yAccessor: string;
-    $: xLabel = removeTimezoneOffset(point[xAccessor]);
+    $: xStartLabel = removeTimezoneOffset(point.ts_start);
+    $: xEndLabel = removeTimezoneOffset(point.ts_end);
 </script>
 
 <g>
@@ -56,19 +59,13 @@
             class="fill-gray-500"
             use:outline
         >
-            {datePortion(xLabel)}
+            {standardTimestampFormat(xStartLabel)} - {standardTimestampFormat(
+                xEndLabel
+            )}
         </text>
         <text
             x={$config.plotLeft}
             y={$config.fontSize * 2 + $config.textGap}
-            class="fill-gray-500"
-            use:outline
-        >
-            {timePortion(xLabel)}
-        </text>
-        <text
-            x={$config.plotLeft}
-            y={$config.fontSize * 3 + $config.textGap * 2}
             class="fill-gray-500"
             use:outline
         >

--- a/src/dataAPI/ProfileModel.ts
+++ b/src/dataAPI/ProfileModel.ts
@@ -190,37 +190,19 @@ export class ProfileModel {
                     cd.summary.statistics = statistics;
                     cd.summary.histogram = chartData;
                 } else if (TIMESTAMPS.has(col_type)) {
-                    const chartData = await this.executor.getTempBinnedData(dfName, col_name);
-                    cd.summary.histogram = chartData;
+                    const { timebin, histogram } = await this.executor.getTempBinnedData(dfName, col_name);
                     const interval = await this.executor.getTempInterval(dfName, col_name);
 
-                    // get max and min and calculate interval
-                    const minDate = chartData[0]?.low
-                        ? new Date(chartData[0].low * 1000)
-                        : undefined;
-
-                    const maxDate = chartData[chartData.length - 1]?.high
-                        ? new Date(chartData[chartData.length - 1].high * 1000)
-                        : undefined;
-
-                    // Rollup to the right edge of each bin, except for 1st bin
-                    const rolledUp: TimeBin[] = chartData.map(d => ({
-                        ts: new Date(d.high * 1000),
-                        count: d.count
-                    }));
-
-                    if (rolledUp[0]) {
-                        rolledUp[0].ts = minDate;
-                    }
+                    cd.summary.histogram = histogram;
 
                     const timeSummary: TimeColumnSummary = {
                         interval,
                         rollup: {
-                            results: rolledUp,
-                            spark: rolledUp,
+                            results: timebin,
+                            spark: timebin,
                             timeRange: {
-                                start: minDate,
-                                end: maxDate,
+                                start: timebin[0]?.ts_start,
+                                end: timebin[timebin.length - 1]?.ts_end,
                                 interval: interval
                             }
                         }

--- a/src/dataAPI/jupyter/PythonExecutor.ts
+++ b/src/dataAPI/jupyter/PythonExecutor.ts
@@ -422,14 +422,12 @@ export class PythonPandasExecutor {
 
                 const lowDate = new Date(lowNum * 1000)
                 const highDate = new Date(highNum * 1000)
-                const midpointDate = new Date((lowDate.getTime() + highDate.getTime()) / 2)
 
                 // for time detail chart
                 timebinData.push({
                     // Pandas extends the minimum bin an arbitrary number below the col's minimum so we shift the lowest bin boundary to the actual minimum
                     ts_start: i === 0 ? new Date(true_minimum * 1000) : lowDate,
                     ts_end: highDate,
-                    ts_midpoint: midpointDate,
                     count: json_res[k],
                 });
 

--- a/src/dataAPI/jupyter/PythonExecutor.ts
+++ b/src/dataAPI/jupyter/PythonExecutor.ts
@@ -7,7 +7,8 @@ import type {
     IColMeta,
     IHistogram,
     ValueCount,
-    Interval
+    Interval,
+    TimeBin
 } from '../../common/exchangeInterfaces';
 
 type ExecResult = { content: string[]; exec_count: number };
@@ -390,8 +391,8 @@ export class PythonPandasExecutor {
     public async getTempBinnedData(
         dfName: string,
         colName: string,
-        maxbins = 100
-    ): Promise<IHistogram> {
+        maxbins = 200
+    ): Promise<{ timebin: TimeBin[], histogram: IHistogram }> {
         try {
             const bin_code = `print( (${dfName}["${replaceSpecial(
                 colName
@@ -407,7 +408,8 @@ export class PythonPandasExecutor {
                 [bin_code, min_value_code].join('\n')
             );
             const content = res['content'];
-            const data: IHistogram = [];
+            const timebinData: TimeBin[] = [];
+            const histogram: IHistogram = []
             const json_res = JSON.parse(content[0].replace(/'/g, '')); // remove single quotes bc not JSON parseable
             const true_minimum = parseFloat(content[1]);
 
@@ -415,18 +417,36 @@ export class PythonPandasExecutor {
                 const cleank = k.replace(/[\])}[{(]/g, ''); // comes in interval formatting like [22, 50)
                 const [low, high] = cleank.split(',');
 
-                data.push({
+                const lowNum = parseFloat(low)
+                const highNum = parseFloat(high)
+
+                const lowDate = new Date(lowNum * 1000)
+                const highDate = new Date(highNum * 1000)
+                const midpointDate = new Date((lowDate.getTime() + highDate.getTime()) / 2)
+
+                // for time detail chart
+                timebinData.push({
                     // Pandas extends the minimum bin an arbitrary number below the col's minimum so we shift the lowest bin boundary to the actual minimum
-                    low: i === 0 ? true_minimum : parseFloat(low),
-                    high: parseFloat(high),
+                    ts_start: i === 0 ? new Date(true_minimum * 1000) : lowDate,
+                    ts_end: highDate,
+                    ts_midpoint: midpointDate,
                     count: json_res[k],
-                    bucket: i
                 });
+
+                // for histogram preview
+                histogram.push(
+                    {
+                        low: i === 0 ? true_minimum : lowNum,
+                        high: highNum,
+                        count: json_res[k],
+                        bucket: i
+                    }
+                )
             });
-            return data;
+            return { timebin: timebinData, histogram: histogram };
         } catch (error) {
             console.warn('[Error caught] in getTempBinnedData', error);
-            return [];
+            return { timebin: [], histogram: [] };
         }
     }
 

--- a/style/base.css
+++ b/style/base.css
@@ -14,12 +14,12 @@
 
     /* text-align: center; */
     overflow-y: auto;
-    min-width: 350px;
+    min-width: 400px;
     width: 450px;
 }
 
 .auto-profile-wrapper {
-    min-width: 320px;
+    min-width: 400px;
 }
 
 #header-icon {


### PR DESCRIPTION
## Functionality

- add labels for both ends of timestamp bound
- Since each point as a bin, the label now has both edges of that bin; they are plotted at the right side of the bin but since they are equal width it doesnt really matter

This is similar style to the charts on npm for package downloads, e.g. the [digautoprofile npm page](https://www.npmjs.com/package/digautoprofile):

<img width="414" alt="Screen Shot 2022-10-26 at 6 38 12 PM" src="https://user-images.githubusercontent.com/13400543/198152016-b79f3e1f-c259-4e9c-8be1-641f9c223851.png">


## Issues addressed

Fixes #46 since better label, we are not doing chart pixel wide rollup but it still works ok
